### PR TITLE
Support Random Seeds

### DIFF
--- a/enemy_catalog.py
+++ b/enemy_catalog.py
@@ -482,6 +482,11 @@ def lagavulin():
 remaining_act1_encounters = [gremlin_gang, large_slime, lots_of_slimes, blue_slaver, red_slaver,
                              three_louses, two_fungi_beasts, exordium_thugs, exordium_wildlife, looter]
 
-act1_normal_encounters = [random.choice(first3_encounters)() for _ in range(3)] + [random.choices(remaining_act1_encounters, weights=[6.25, 12.5, 6.35, 12.5, 6.25, 12.5, 12.5, 9.375, 9.375, 12.5], k=1)[0]() for _ in range(15)]
-act1_elites = [random.choice([gremlin_nob, sentries, lagavulin])() for _ in range(4)]
-act1_boss = [random.choice([SlimeBoss(), Hexaghost(player.health), Guardian()])]
+def create_act1_normal_encounters():
+    return [random.choice(first3_encounters)() for _ in range(3)] + [random.choices(remaining_act1_encounters, weights=[6.25, 12.5, 6.35, 12.5, 6.25, 12.5, 12.5, 9.375, 9.375, 12.5], k=1)[0]() for _ in range(15)]
+
+def create_act1_elites():
+    return [random.choice([gremlin_nob, sentries, lagavulin])() for _ in range(4)]
+
+def create_act1_boss():
+    return [random.choice([SlimeBoss(), Hexaghost(player.health), Guardian()])]

--- a/game.py
+++ b/game.py
@@ -6,7 +6,7 @@ from ansi_tags import ansiprint
 from events import choose_event
 from items import relics, potions, cards, activate_sacred_bark
 from helper import active_enemies, combat_turn, potion_dropchance, view, gen, ei
-from enemy_catalog import act1_normal_encounters, act1_elites, act1_boss
+from enemy_catalog import create_act1_normal_encounters, create_act1_elites, create_act1_boss
 from entities import player
 
 def combat(tier) -> None:
@@ -218,6 +218,9 @@ def start_combat(combat_tier):
     player.in_combat = True
     # Shuffles the player's deck into their draw pile
     player.draw_pile = random.sample(player.deck, len(player.deck))
+    act1_normal_encounters  = create_act1_normal_encounters()
+    act1_elites = create_act1_elites()
+    act1_boss = create_act1_boss()
     encounter_types = {'Normal': act1_normal_encounters, 'Elite': act1_elites, 'Boss': act1_boss}
     encounter_enemies = encounter_types[combat_tier][0]
     for enemy in encounter_enemies:

--- a/game.py
+++ b/game.py
@@ -278,7 +278,9 @@ def play_card(card):
     player.use_card(card, active_enemies[target], False, player.hand)
 
 
-def main():
+def main(seed=None):
+    if seed is not None:
+        random.seed(seed)
     encounter_weights = [0.45, 0.24, 0.19, 0.12]
     possible_encounters = [lambda: combat("Normal"), unknown, lambda: combat("Elite"), rest_site]
     # Note that Elite and Boss encounters don't exist yet, so those are replaced with normal combats

--- a/main.py
+++ b/main.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python3
 from game import main
+from argparse import ArgumentParser
 
 if __name__ == '__main__':
-    main()
+    args = ArgumentParser(description="Run a game of Slay the Spire")
+    args.add_argument('-s', '--seed', type=int, help="Seed to use for the game", default=None)
+    main(seed=args.parse_args().seed)


### PR DESCRIPTION
### What
Adds an option to select the random seed for the game. This makes it so that the random number generator creates the same sequence, which results in an exactly replayable game. 

For example, if you start the game with `main.py -s 15`, you should be facing the following combat scenario:

```
Hand: 
1: Strike | Attack | 1 Energy | Deal 6 damage.
2: Defend | Skill | 1 Energy | Gain 5 Block.
3: Defend | Skill | 1 Energy | Gain 5 Block.
4: Strike | Attack | 1 Energy | Deal 6 damage.
5: Strike | Attack | 1 Energy | Deal 6 damage.

Enemies:
1: Acid Slime (M) (31 / 31 | 0 Block) | Intent: Debuff
2: Spike Slime (S) (13 / 13 | 0 Block) | Intent: Attack 5
```

### So What
In lieu of unit tests, this improvement is good for identifying bugs. For example, I could specify a game sequence:
```
Seed: 15
Keystrokes: 1,1 (Strike Acid Slime)
Expected Behaviour: Acid Slime health reduced and Ironclad energy reduced
Actual Behaviour: No change in stats
```

### Now What
If a bug is identified, we can create an issue with the seed and keystrokes to repeat the bug. 

These seed+keystroke combinations will not be stable over the long term. Any changes in code that create additional calls to `random` will invalidate all existing sequences. Unit tests around the combat system would be better. But this is a good start.