### PR TITLE
Skip the coverage comment when testing the main branch

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,23 +17,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
         python-version: "3.11"
+
     - name: Install Poetry
       uses: snok/install-poetry@v1
+
     - name: Install dependencies
       run: |
         poetry install
+
     - name: Test with pytest
       run: |
         poetry run pytest -s
+
     - name: Build coverage file
       run: |
         poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=. | tee pytest-coverage.txt
+
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@main
       with:
         pytest-coverage-path: ./pytest-coverage.txt
         junitxml-path: ./pytest.xml
+      if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
Main branch CI fails unnecessarily because it tries to put a comment on a PR, but there's no PR to comment. This skips that part.