### PR TITLE
PendingAction with tests

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -19,7 +19,7 @@ from definitions import (
 from message_bus_tools import Effect, Message, bus
 
 if TYPE_CHECKING:
-    from entities import Enemy, Player, Action
+    from entities import Enemy, Player, PendingAction
     from items import Card
 
 
@@ -463,7 +463,7 @@ class NoDraw(Effect):
     def __init__(self, host, _):
         super().__init__(host, "No Draw", StackType.NONE, EffectType.DEBUFF, "You may not draw any more cards this turn.")
 
-    def callback(self, message, data: tuple[Player, Action]):
+    def callback(self, message, data: tuple[Player, PendingAction]):
         if message == Message.BEFORE_DRAW:
             player, action = data
             action.cancel(reason="You cannot draw any cards because of <debuff>No Draw</debuff>.")
@@ -574,7 +574,7 @@ class Barricade(Effect):
         super().__init__(host, "Barricade", StackType.NONE, EffectType.BUFF, "<keyword>Block</keyword> is not removed at the start of your turn.", amount)
         self.end_of_turn_block = None
 
-    def callback(self, message, data: tuple[Player, Action] | tuple[Player, list[Enemy]]):
+    def callback(self, message, data: tuple[Player, PendingAction] | tuple[Player, list[Enemy]]):
         if message == Message.END_OF_TURN:
             player, enemies = data
             self.end_of_turn_block = player.block

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -55,3 +55,56 @@ def test_all_attack_cards_with_all_relics(monkeypatch):
           print(f"Playing card {idx} of {initial_size} - {card.name}")
           player.use_card(card=card, enemies=[boss], target=boss, exhaust=True, pile=player.draw_pile)
 
+
+class TestPendingAction():
+    def test_pending_action_str_and_repl(self):
+        pa = entities.PendingAction("draw_cards", lambda: None, 100)
+        assert str(pa) == "PendingAction: draw_cards(100)"
+        assert repr(pa) == "PendingAction: draw_cards(100)"
+
+    def test_pending_action_can_set_argument(self):
+        def action(arg1):
+            print(f"Action executed with arg1={arg1}")
+            return arg1
+
+        pa = entities.PendingAction("PendingAction", action, 1)
+        pa.set_amount(2)
+        assert pa.amount == 2
+        assert pa.execute() == 2
+
+    def test_pending_action_can_modify_argument(self):
+        def action(arg1):
+            print(f"Action executed with arg1={arg1}")
+            return arg1
+
+        pa = entities.PendingAction("PendingAction", action, 1)
+        pa.increase_amount(2)
+        assert pa.amount == 3
+        assert pa.execute() == 3
+
+    def test_pending_action_can_be_cancelled(self):
+        num_times_called = 0
+        def action(arg1):
+            nonlocal num_times_called
+            print(f"Action executed with arg1={arg1}")
+            num_times_called += 1
+            return arg1
+
+        pa = entities.PendingAction("PendingAction", action, 1)
+        pa.cancel()
+        assert pa.execute() is None
+        assert pa.execute() is None
+        assert num_times_called == 0
+
+    def test_pending_action_can_only_be_executed_once(self):
+        num_times_called = 0
+        def action(arg1):
+            nonlocal num_times_called
+            print(f"Action executed with arg1={arg1}")
+            num_times_called += 1
+            return arg1
+
+        pa = entities.PendingAction("PendingAction", action, 1)
+        assert pa.execute() == 1
+        assert pa.execute() is None
+        assert num_times_called == 1


### PR DESCRIPTION
Example of `PendingAction` with tests.

Lets you specify an action, then publish it to the message bus where others can modify/cancel it, then you can execute it. 

So it could let you publish `draw_cards(x)`, to let that be modified. Or `blocking(x)`. Or really anything. 

Only supports functions with a single argument. 